### PR TITLE
Adjust compose file to acommodate interface container

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,7 @@ services:
     environment:
       MYSQL_DATABASE: ${DB_NAME}
       MYSQL_ROOT_PASSWORD: ${DB_PASS}
+      MYSQL_USER: ${DB_USERNAME}
       MYSQL_PASSWORD: ${DB_PASS}
 
     volumes:


### PR DESCRIPTION
Changes made in the compose file are in order to broadcast the container and network names so the Interface container can connect to them.

In order to run ZombieProject and ZombieProjectInterface simultaneously, first you have to clone the Interface repo. The way in which I wrote the .env file assumes ZombieProject and Interface are sibling directories that share the same root. Adjust to your liking.

A change is required locally on your end to the .env file:
Add the following line: 
COMPOSE_FILE=compose.yaml:../ZombieProjectInterface/compose.yaml

To run the project: docker compose up --build from ZombieProject dir.

